### PR TITLE
Add entersearch while handling autocomplete usage

### DIFF
--- a/ReplayBrowser/Pages/Shared/MainLayout.razor
+++ b/ReplayBrowser/Pages/Shared/MainLayout.razor
@@ -87,7 +87,7 @@
 
 <footer class="footer text-muted text-center">
     <div class="container">
-        <p>Replay Browser is a project by Simyon (so far no other contributors). Source code available on <a href="https://github.com/Simyon264/ReplayBrowser">GitHub</a>.</p>
+        <p>Replay Browser is a project by Simyon and YuNii. Source code available on <a href="https://github.com/Simyon264/ReplayBrowser">GitHub</a>.</p>
     </div>
     
     <div class="container">

--- a/ReplayBrowser/Pages/Shared/SearchBar.razor
+++ b/ReplayBrowser/Pages/Shared/SearchBar.razor
@@ -45,6 +45,9 @@
 </style>
 
 <script>
+
+    let selectedAutocompleteOption = null;
+    
     // This is a script to make the dropdown change the text of the button
     const dropdowns = document.querySelectorAll('.dropdown-menu a');
     dropdowns.forEach((dropdown) => {
@@ -53,10 +56,18 @@
             document.getElementById('searchModeButton').textContent = text;
         });
     });
+
+    // event listener to track selected autocomplete option
+    $('#search').on('autocomplete:selected', function (event, suggestion, dataset) {
+        selectedAutocompleteOption = suggestion;
+    });
         
     function search(page) {
         const searchMode = document.getElementById('searchModeButton').textContent;
         const searchText = document.querySelector('.search-bar input').value;
+
+        // sanity check
+        if(page === null) page = 0;
         
         const builder = new URLSearchParams();
         builder.append('mode', searchMode);
@@ -64,11 +75,11 @@
         builder.append('page', page);
         window.location.href = '/search?' + builder.toString();
     }
-    
+
     document.querySelector('.search-bar input').addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-            //search(0);
-            //Temporary remove since autocomplete uses enter to select
+        if (e.key === 'Enter' && !e.defaultPrevented) {
+            console.log("search")
+            search(0);
         }
     });
     
@@ -86,6 +97,12 @@
                     // Currently, autocomplete only supports searching for player names. So delete the item
                     item.remove();
                 }   
+            },
+            onPick(el, item) {
+                selectedAutocompleteOption = item.innerHTML;
+                console.log("onpick", selectedAutocompleteOption, item.innerHTML)
+                document.querySelector('.search-bar input').value = selectedAutocompleteOption;
+                search(0)
             }
         })
     }, false);

--- a/ReplayBrowser/Pages/Shared/SearchBar.razor
+++ b/ReplayBrowser/Pages/Shared/SearchBar.razor
@@ -77,8 +77,7 @@
     }
 
     document.querySelector('.search-bar input').addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' && !e.defaultPrevented) {
-            console.log("search")
+        if (e.key === 'Enter' && !e.defaultPrevented) {)
             search(0);
         }
     });
@@ -100,7 +99,6 @@
             },
             onPick(el, item) {
                 selectedAutocompleteOption = item.innerHTML;
-                console.log("onpick", selectedAutocompleteOption, item.innerHTML)
                 document.querySelector('.search-bar input').value = selectedAutocompleteOption;
                 search(0)
             }


### PR DESCRIPTION
Add the ability to press enter to search. Before this was disabled since it conflicted with the autocomplete, since it's options are selected with Enter. Now those two are dynamically handled, meaning that pressing enter with a autocomplete option selected searches for that option instead.